### PR TITLE
Display icons from the internet

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math/rand"
 	"path/filepath"
+	"strconv"
 
 	"github.com/spf13/cobra"
 	toast "gopkg.in/toast.v1"
@@ -42,17 +44,21 @@ func main() {
 				return
 			}
 
+			// only use 100 random file names to avoid too much garbage since this application closes before the windows executable completes
+			// not allowing us to delete the file after the toast is invoked
+			random := strconv.Itoa(rand.Intn(100) + 1)
+
 			if len(icon) > 0 && (icon[:7] == "http://" || icon[:8] == "https://") {
 				tmpFolder := os.TempDir()
 
-				err := DownloadFile(icon, filepath.Join(tmpFolder, "wsl-notify-send-icon-tmp.png"))
+				err := DownloadFile(icon, filepath.Join(tmpFolder, "wsl-notify-send-icon-tmp"+random+".png"))
 				if err != nil {
 					log.Fatalln(err)
 					icon = ""
 				} else {
 					// had to comment this out because the toast wasn't getting invoked before the file was removed
-					// defer os.Remove("wsl-notify-send-icon-tmp.png")
-					icon = filepath.Join(tmpFolder, "wsl-notify-send-icon-tmp.png")
+					// defer os.Remove("wsl-notify-send-icon-tmp"+random+".png")
+					icon = filepath.Join(tmpFolder, "wsl-notify-send-icon-tmp"+random+".png")
 				}
 			}
 

--- a/main.go
+++ b/main.go
@@ -2,10 +2,15 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"log"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 	toast "gopkg.in/toast.v1"
+
+	"net/http"
+	"os"
 )
 
 // Overridden via ldflags
@@ -36,6 +41,21 @@ func main() {
 				_ = cmd.Usage()
 				return
 			}
+
+			if len(icon) > 0 && (icon[:7] == "http://" || icon[:8] == "https://") {
+				tmpFolder := os.TempDir()
+
+				err := DownloadFile(icon, filepath.Join(tmpFolder, "wsl-notify-send-icon-tmp.png"))
+				if err != nil {
+					log.Fatalln(err)
+					icon = ""
+				} else {
+					// had to comment this out because the toast wasn't getting invoked before the file was removed
+					// defer os.Remove("wsl-notify-send-icon-tmp.png")
+					icon = filepath.Join(tmpFolder, "wsl-notify-send-icon-tmp.png")
+				}
+			}
+
 			notification := &toast.Notification{
 				AppID:   appID,
 				Title:   category,
@@ -60,6 +80,33 @@ func main() {
 	rootCmd.Flags().StringVar(&appID, "appId", "wsl-notify-send", "[non-standard] Specifies the app ID")
 	rootCmd.Flags().BoolVar(&showVersion, "version", false, "Show version information")
 	_ = rootCmd.Execute()
+}
+
+// DownloadFile will download a url and store it in local filepath.
+// It writes to the destination file as it downloads it, without
+// loading the entire file into memory.
+func DownloadFile(url string, filepath string) error {
+	// Create the file
+	out, err := os.Create(filepath)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	// Get the data
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	// Write the body to file
+	_, err = io.Copy(out, resp.Body)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // TODO - explore mapping icons: https://wiki.ubuntu.com/NotificationDevelopmentGuidelines#How_do_I_get_these_slick_icons


### PR DESCRIPTION
This is a quick hack to display icons from the internet. It may not be up to the code standards of the original repository, but I make this available in case anyone is interested.

Urls can be passed to the icon argument:

```
C:\Users\Jonathan\bin\wsl-notify-send.exe --appId "Pianobar" --category "QuickMix" "Taylor Swift `nFearless (Taylor's Version) `nLove Story (Taylor’s Version)" -i "http://mediaserver-cont-sv5-1-v4v6.pandora.com/images/d6/67/f1/00/10cb41e492bfb926c7790f88/1080W_1080H.jpg"
```

Results in:
![image](https://github.com/stuartleeks/wsl-notify-send/assets/1827190/ad10e4d7-c655-40c9-99d7-32094be97be6)


Binary release available at:
https://github.com/jonmchan/wsl-notify-send/releases/tag/2024-07-05-internet-icon-support